### PR TITLE
feat: 힌트 버튼 완성

### DIFF
--- a/frontend/src/components/playroom-btn/hint-btn/index.tsx
+++ b/frontend/src/components/playroom-btn/hint-btn/index.tsx
@@ -26,6 +26,7 @@ const HintBtn = ({ hintFunc, hintState }: HintBtnProps) => {
 };
 
 const HintButton = styled.button`
+  z-index: 2;
   background: none;
   border: none;
   padding: 0px;

--- a/frontend/src/components/playroom-btn/index.tsx
+++ b/frontend/src/components/playroom-btn/index.tsx
@@ -36,6 +36,7 @@ interface MenuDetailType {
 }
 
 const MenuWrap = styled.div`
+  z-index: 2;
   position: absolute;
   right: 5%;
   bottom: 5%;

--- a/frontend/src/pages/play-puzzle/index.tsx
+++ b/frontend/src/pages/play-puzzle/index.tsx
@@ -107,6 +107,7 @@ const Body = styled.div`
 `;
 
 const ComponentImg = styled.img<ComponentImgType>`
+  z-index: 1;
   object-fit: scale-down;
   width: 80%;
   height: 80%;


### PR DESCRIPTION
- 기존의 힌트 사진 깜박거림 이유는 힌트 사진이 버튼 위에 위치하여 사진이
  뜨면 mouseLeave 이벤트가 함께 작동한 것이 원인
- z-index를 설정해 버튼을 위쪽으로 올렸더니 해결되었다.