### PR TITLE
fix: 플레이룸 메뉴 버튼 위치 및 크기 css 수정

### DIFF
--- a/frontend/src/components/play-puzzle/playroom-btn/index.tsx
+++ b/frontend/src/components/play-puzzle/playroom-btn/index.tsx
@@ -35,16 +35,28 @@ interface MenuDetailType {
   show: boolean;
 }
 
+const MenuBtnLoc = {
+  right: 0.08,
+  bottom: 0.03,
+};
+
+const MenuDetailRelativeLoc = {
+  right: 75,
+  bottom: 95,
+};
+
 const MenuWrap = styled.div`
   z-index: 2;
-  position: absolute;
-  right: 5%;
-  bottom: 5%;
   display: flex;
   flex-direction: column;
   align-items: center;
 `;
 const MenuDetailWrap = styled.div<MenuDetailType>`
+  position: absolute;
+  right: ${window.innerWidth * MenuBtnLoc.right -
+  MenuDetailRelativeLoc.right}px;
+  bottom: ${window.innerHeight * MenuBtnLoc.bottom +
+  MenuDetailRelativeLoc.bottom}px;
   display: ${(props) => (props.show ? "flex" : "none")};
   margin-bottom: 20px;
   padding: 10px 40px;
@@ -57,13 +69,15 @@ const MenuDetailWrap = styled.div<MenuDetailType>`
   border-radius: 50px;
 `;
 const MenuButtonWrap = styled.div`
-  width: 250px;
   display: flex;
   justify-content: center;
   align-items: center;
 `;
 
 const MenuButton = styled.button`
+  position: absolute;
+  right: ${window.innerWidth * MenuBtnLoc.right}px;
+  bottom: ${window.innerHeight * MenuBtnLoc.bottom}px;
   background: none;
   border: none;
   padding: 0px;


### PR DESCRIPTION
- 기존의 버튼 영역이 넓어 뒷쪽 퍼즐이 클릭되지 않던 문제 수정