### PR TITLE
feat: 캔버스 크기 작은 모니터 기준 고정

### DIFF
--- a/frontend/src/components/play-puzzle/puzzle-canvas/index.tsx
+++ b/frontend/src/components/play-puzzle/puzzle-canvas/index.tsx
@@ -9,7 +9,7 @@ import { completeAnimation } from "@components/play-puzzle/puzzle-canvas/puzzle/
 
 type LevelSizeType = { 1: number; 2: number; 3: number };
 type Levels = 1 | 2 | 3;
-const levelSize: LevelSizeType = { 1: 300, 2: 500, 3: 800 };
+const levelSize: LevelSizeType = { 1: 300, 2: 500, 3: 600 };
 type Config = {
   originHeight: number;
   originWidth: number;
@@ -166,15 +166,19 @@ const PuzzleCanvas = (props: any) => {
 };
 
 const Canvas = styled.canvas`
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  width: 1280px;
+  height: 765px;
+  top: ${(window.innerHeight + 35) / 2}px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  box-sizing: border-box;
+  border: 2px solid #000000;
 `;
 
 const Wrapper = styled.div`
   width: 100%;
   height: 100%;
-  padding: 50px 0;
-  box-sizing: border-box;
 `;
 
 export default PuzzleCanvas;

--- a/frontend/src/components/play-puzzle/puzzle-canvas/puzzle/move-puzzle.tsx
+++ b/frontend/src/components/play-puzzle/puzzle-canvas/puzzle/move-puzzle.tsx
@@ -90,10 +90,9 @@ const initConfig = () => {
       const index2 = config.tileIndexes[index1];
       const tile = config.tiles[index2];
       config.tileIndexes.splice(index1, 1);
-
       const position = new Point(
         config.project.view.center.x -
-          config.tileWidth +
+          config.tileWidth / 2 +
           config.tileWidth * (x * 2 + (y % 2)) -
           config.imgWidth,
         config.project.view.center.y -


### PR DESCRIPTION
- 작은 모니터에서 퍼즐이 나오지 않던 문제 해결
- 기준 사이즈: 1280 x 800
- 퍼즐 조각 위치 가운데로 조정 필요